### PR TITLE
Fixed Routing Error

### DIFF
--- a/script.js
+++ b/script.js
@@ -62,8 +62,7 @@ const init = async ()=> {
         $('#tiles div.project:last-child').css({
             'background-image': `url('./img/${project.img}')`
         }).on('click', x=> {
-            $('body').append(`<a id="redirect" href="${project.url}" />`);
-            $('#redirect').get(0).click();
+            window.location.href = project.url;
         }).children('p').css({
             height: 0,
             "font-size": 0,


### PR DESCRIPTION
Your page has the problem that after selecting one of the tiles none of the other tiles can be selected correctly. You always end up with the first selection. 

For example, if I click on Research: AI development, then go back in the browser and click on Computer Vision Library, I end up back at AI Development.

To fix this, I removed 2 lines of code:
`$('body').append(`<a id="redirect" href="${project.url}" />`);`
`$('#redirect').get(0).click();`

with this line of code:
`window.location.href = project.url;`

Already tested it with Chrome Overrides and it seems to work 👍 